### PR TITLE
Always load SamuraiDash.scene

### DIFF
--- a/Assets/Scenes/SamuraiDash.scene
+++ b/Assets/Scenes/SamuraiDash.scene
@@ -1,7 +1,8 @@
-[Spline]
-name     = "Spline"
+# This is the scene file for samurai-dash, add any static items here (models, animations, particles, ...)
 
-# This should draw a coordinate system with 3 colored axes
+# <coordinate-system>
+# The following is the coordinate system from CoordinateSystem.scene
+# It is meant to be a reference point for development purposes.
 
 [Cube]
 name = "X-axis"
@@ -25,3 +26,5 @@ scaling = 1.0f 0.1f 0.1f
 name = "Origin"
 position = 0.0f 0.0f 0.0f
 scaling = 0.12f 0.12f 0.12f
+
+# </coordinate-system>

--- a/Source/SplineFactory.cpp
+++ b/Source/SplineFactory.cpp
@@ -1,13 +1,22 @@
+#include <iostream>
+
 #include "SplineFactory.h"
 
+using namespace std;
 using namespace glm;
 
-SplineModel* SplineFactory::LoadSpline(ci_istringstream& iss) {
+const ci_string SplineFactory::splineName = "Spline";
+
+SplineModel* SplineFactory::LoadSpline() {
 	
 	SplineModel* splineModel = new SplineModel();
 	SplineModel& spline = *splineModel;
 
-	spline.Load(iss);
+	ci_stringstream outName;
+	outName << "name = \"" << splineName << "\"";
+	ci_istringstream inName(outName.str());
+
+	spline.Load(inName);
 
 	if (!spline.HasControlPoints()) {
 		makeControlPoints(spline);

--- a/Source/SplineFactory.h
+++ b/Source/SplineFactory.h
@@ -13,7 +13,12 @@ class SplineFactoryPlaneDelegate : public SplineModelPlaneDelegate {
 class SplineFactory {
 
 public:
-	static SplineModel* LoadSpline(ci_istringstream& iss);
+	/**
+	 * The name of the loaded spline model
+	 */
+	static const ci_string splineName;
+
+	static SplineModel* LoadSpline();
 
 private:
 

--- a/Source/World.cpp
+++ b/Source/World.cpp
@@ -29,6 +29,12 @@
 using namespace std;
 using namespace glm;
 
+#if defined(PLATFORM_OSX)
+const char* World::sceneFile = "Scenes/SamuraiDash.scene";
+#else
+const char* World::sceneFile = "../Assets/Scenes/SamuraiDash.scene";
+#endif
+
 World* World::instance;
 
 World::World()
@@ -247,6 +253,21 @@ void World::Draw()
 	Renderer::EndFrame();
 }
 
+void World::LoadScene() {
+
+	// The world's scene for samurai-dash
+	// Do any complex dynamic initialization in here
+
+	// There will always be a spline in samurai-dash
+	SplineModel* spline = SplineFactory::LoadSpline();
+	mModel.push_back(spline);
+	
+	// ...
+
+	// Finally the static samurai-dash scene is loaded
+	LoadScene(sceneFile);
+}
+
 void World::LoadScene(const char * scene_path)
 {
 	// Using case-insensitive strings and streams for easier parsing
@@ -293,11 +314,6 @@ void World::LoadScene(const char * scene_path)
 				Animation* anim = new Animation();
 				anim->Load(iss);
 				mAnimation.push_back(anim);
-			}
-			else if (result == "spline")
-			{
-				SplineModel* spline = SplineFactory::LoadSpline(iss);
-				mModel.push_back(spline);
 			}
 			else if ( result.empty() == false && result[0] == '#')
 			{

--- a/Source/World.h
+++ b/Source/World.h
@@ -22,6 +22,8 @@ class ParticleSystem;
 class World
 {
 public:
+	static const char* sceneFile;
+
 	World();
 	~World();
 	
@@ -30,7 +32,10 @@ public:
 	void Update(float dt);
 	void Draw();
 
+	void World::LoadScene();
+
 	void LoadScene(const char * scene_path);
+
     Animation* FindAnimation(ci_string animName);
 	AnimationKey* FindAnimationKey(ci_string keyName);
 
@@ -41,6 +46,7 @@ public:
     void RemoveParticleSystem(ParticleSystem* particleSystem);
     
 	Camera* GetCamera() { return mCamera[mCurrentCamera]; }
+
 private:
     static World* instance;
     

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -32,29 +32,31 @@ int main(int argc, char*argv[])
 
 	World world;    
     
-	if (argc > 1)
-	{
-		world.LoadScene(argv[1]);
-	}
-	else
-	{
-		// TODO - You can alternate between different scenes for testing different things
-		// Static Scene contains no animation
-		// Animated Scene does
-#if defined(PLATFORM_OSX)		
-//		world.LoadScene("Scenes/AnimatedSceneWithParticles.scene");
-		world.LoadScene("Scenes/Spline.scene");
-//		world.LoadScene("Scenes/AnimatedScene.scene");
-//		world.LoadScene("Scenes/StaticScene.scene");
-//		world.LoadScene("Scenes/CoordinateSystem.scene");
-#else
-//		world.LoadScene("../Assets/Scenes/AnimatedSceneWithParticles.scene");
-//		world.LoadScene("../Assets/Scenes/AnimatedScene.scene");
-		world.LoadScene("../Assets/Scenes/Spline.scene");
-//		world.LoadScene("../Assets/Scenes/StaticScene.scene");
-//		world.LoadScene("../Assets/Scenes/CoordinateSystem.scene");
-#endif
-	}
+	world.LoadScene();
+
+//	if (argc > 1)
+//	{
+//		world.LoadScene(argv[1]);
+//	}
+//	else
+//	{
+//		// TODO - You can alternate between different scenes for testing different things
+//		// Static Scene contains no animation
+//		// Animated Scene does
+//#if defined(PLATFORM_OSX)		
+////		world.LoadScene("Scenes/AnimatedSceneWithParticles.scene");
+//		world.LoadScene("Scenes/Spline.scene");
+////		world.LoadScene("Scenes/AnimatedScene.scene");
+////		world.LoadScene("Scenes/StaticScene.scene");
+////		world.LoadScene("Scenes/CoordinateSystem.scene");
+//#else
+////		world.LoadScene("../Assets/Scenes/AnimatedSceneWithParticles.scene");
+////		world.LoadScene("../Assets/Scenes/AnimatedScene.scene");
+//		world.LoadScene("../Assets/Scenes/Spline.scene");
+////		world.LoadScene("../Assets/Scenes/StaticScene.scene");
+////		world.LoadScene("../Assets/Scenes/CoordinateSystem.scene");
+//#endif
+//	}
 
 	double fps = 1.0f / FPS;
 

--- a/VS2013/Assignment1.vcxproj
+++ b/VS2013/Assignment1.vcxproj
@@ -101,6 +101,7 @@
     <None Include="..\Assets\Scenes\AnimatedScene.scene" />
     <None Include="..\Assets\Scenes\AnimatedSceneWithParticles.scene" />
     <None Include="..\Assets\Scenes\CoordinateSystem.scene" />
+    <None Include="..\Assets\Scenes\SamuraiDash.scene" />
     <None Include="..\Assets\Scenes\StaticScene.scene" />
     <None Include="..\Assets\Shaders\BlueColor.fragmentshader" />
     <None Include="..\Assets\Shaders\PathLines.fragmentshader" />

--- a/VS2013/Assignment1.vcxproj.filters
+++ b/VS2013/Assignment1.vcxproj.filters
@@ -59,6 +59,9 @@
     <None Include="..\Assets\Shaders\Spline.vertexshader">
       <Filter>Resource Files\Shaders</Filter>
     </None>
+    <None Include="..\Assets\Scenes\SamuraiDash.scene">
+      <Filter>Resource Files\Scenes</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Source\ParticleDescriptor.cpp">


### PR DESCRIPTION
main starts with world.LoadScene() which always loads "SamuraiDash.scene" file.

For our project I made a function World::LoadScene where we can add our code to setup the scene.

For example, there will always be a SplineModel that needs to be loaded into the scene for our game.

Then World::LoadScene will call World::LoadScene("SamuraiDash.scene") if we want any other things loaded that we can describe in a scene file.